### PR TITLE
Don't use ToLower() on replay path & parse online score ID as long

### DIFF
--- a/osu-replay-viewer/OsuGameRecorder.cs
+++ b/osu-replay-viewer/OsuGameRecorder.cs
@@ -87,7 +87,7 @@ namespace osu_replay_renderer_netcore
                 }
                 else if (scoreId.StartsWith("file:"))
                 {
-                    string filePath = scoreId.Substring(5);
+                    string filePath = ProgramArguments[1].Substring(5);
                     if (!File.Exists(filePath))
                     {
                         Console.Error.WriteLine("Score not found: " + filePath);


### PR DESCRIPTION
On operating systems with case-sensitive path names like Linux, this will break any replay file that has its path with at least one uppercase character.

Newer online scores have IDs exceeding the Int32 range - parsing them will result in an overflow exception.

This patch should fix those issues.