### PR TITLE
Cross Platform Fix for Recording and Headless Game Host

### DIFF
--- a/osu-replay-viewer/CustomHosts/CrossPlatform.cs
+++ b/osu-replay-viewer/CustomHosts/CrossPlatform.cs
@@ -1,11 +1,9 @@
 ﻿using osu.Framework;
 using osu.Framework.Platform;
+using osu.Framework.Platform.Windows;
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace osu_replay_renderer_netcore.CustomHosts
 {
@@ -27,6 +25,19 @@ namespace osu_replay_renderer_netcore.CustomHosts
                     yield return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Personal), ".local", "share");
                     // foreach (string path in baseHost.UserStoragePaths) yield return path;
                     break;
+
+                default: throw new InvalidOperationException($"Unknown platform: {Enum.GetName(typeof(RuntimeInfo.Platform), RuntimeInfo.OS)}");
+            }
+        }
+
+        public static IWindow GetWindow()
+        {
+            switch (RuntimeInfo.OS)
+            {
+                case RuntimeInfo.Platform.Windows: return new WindowsWindow();
+                case RuntimeInfo.Platform.Linux:
+                case RuntimeInfo.Platform.macOS:
+                    return new SDL2DesktopWindow();
 
                 default: throw new InvalidOperationException($"Unknown platform: {Enum.GetName(typeof(RuntimeInfo.Platform), RuntimeInfo.OS)}");
             }

--- a/osu-replay-viewer/CustomHosts/CrossPlatform.cs
+++ b/osu-replay-viewer/CustomHosts/CrossPlatform.cs
@@ -1,0 +1,35 @@
+﻿using osu.Framework;
+using osu.Framework.Platform;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace osu_replay_renderer_netcore.CustomHosts
+{
+    public static class CrossPlatform
+    {
+        public static IEnumerable<string> GetUserStoragePaths()
+        {
+            switch (RuntimeInfo.OS)
+            {
+                case RuntimeInfo.Platform.Windows:
+                    yield return Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+                    break;
+
+                case RuntimeInfo.Platform.Linux:
+                case RuntimeInfo.Platform.macOS:
+                    // https://github.com/ppy/osu-framework/blob/master/osu.Framework/Platform/Linux/LinuxGameHost.cs
+                    string xdg = Environment.GetEnvironmentVariable("XDG_DATA_HOME");
+                    if (!string.IsNullOrEmpty(xdg)) yield return xdg;
+                    yield return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Personal), ".local", "share");
+                    // foreach (string path in baseHost.UserStoragePaths) yield return path;
+                    break;
+
+                default: throw new InvalidOperationException($"Unknown platform: {Enum.GetName(typeof(RuntimeInfo.Platform), RuntimeInfo.OS)}");
+            }
+        }
+    }
+}

--- a/osu-replay-viewer/CustomHosts/ReplayHeadlessGameHost.cs
+++ b/osu-replay-viewer/CustomHosts/ReplayHeadlessGameHost.cs
@@ -11,9 +11,9 @@ using System.Runtime.InteropServices;
 
 namespace osu_replay_renderer_netcore.CustomHosts
 {
-    public class WindowsHeadlessGameHost : HeadlessGameHost
+    public class ReplayHeadlessGameHost : HeadlessGameHost
     {
-        public override IEnumerable<string> UserStoragePaths => Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData).Yield();
+        public override IEnumerable<string> UserStoragePaths => CrossPlatform.GetUserStoragePaths();
 
         public string OutputAudioToFile { get; set; } = null;
         public int AudioInputDevice { get; set; } = -1;
@@ -23,7 +23,7 @@ namespace osu_replay_renderer_netcore.CustomHosts
         //public int TrackMixerHandle { get; set; } = 0;
         //public int SampleMixerHandle { get; set; } = 0;
 
-        public WindowsHeadlessGameHost(
+        public ReplayHeadlessGameHost(
             string gameName = null,
             bool bindIPC = false,
             bool realtime = true,

--- a/osu-replay-viewer/CustomHosts/ReplayRecordGameHost.cs
+++ b/osu-replay-viewer/CustomHosts/ReplayRecordGameHost.cs
@@ -28,9 +28,10 @@ namespace osu_replay_renderer_netcore.CustomHosts
     /// will be changed in the future (maybe we'll hide it, or maybe we'll implement entire
     /// fake window from scratch to make it render offscreen)
     /// </summary>
-    public class WindowsRecordGameHost : DesktopGameHost
+    public class ReplayRecordGameHost : DesktopGameHost
     {
-        public override IEnumerable<string> UserStoragePaths => Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData).Yield();
+        // public override IEnumerable<string> UserStoragePaths => Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData).Yield();
+        public override IEnumerable<string> UserStoragePaths => CrossPlatform.GetUserStoragePaths();
 
         public override void OpenFileExternally(string filename) => Logger.Log($"Application has requested file \"{filename}\" to be opened.");
         public override void OpenUrlExternally(string url) => Logger.Log($"Application has requested URL \"{url}\" to be opened.");
@@ -44,7 +45,7 @@ namespace osu_replay_renderer_netcore.CustomHosts
         public ExternalFFmpegEncoder Encoder { get; set; }
         public bool UsingEncoder { get; set; } = true;
 
-        public WindowsRecordGameHost(string gameName = null, int frameRate = 60) : base(gameName, false)
+        public ReplayRecordGameHost(string gameName = null, int frameRate = 60) : base(gameName, false)
         {
             recordClock = new RecordClock(frameRate);
         }

--- a/osu-replay-viewer/CustomHosts/ReplayRecordGameHost.cs
+++ b/osu-replay-viewer/CustomHosts/ReplayRecordGameHost.cs
@@ -1,10 +1,8 @@
 ﻿using osu.Framework;
 using osu.Framework.Configuration;
-using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Input.Handlers;
 using osu.Framework.Logging;
 using osu.Framework.Platform;
-using osu.Framework.Platform.Windows;
 using osu.Framework.Timing;
 using osu_replay_renderer_netcore.Audio;
 using osu_replay_renderer_netcore.CustomHosts.Record;
@@ -32,7 +30,7 @@ namespace osu_replay_renderer_netcore.CustomHosts
 
         private RecordClock recordClock;
         protected override IFrameBasedClock SceneGraphClock => recordClock;
-        protected override IWindow CreateWindow() => new WindowsWindow();
+        protected override IWindow CreateWindow() => CrossPlatform.GetWindow();
         protected override IEnumerable<InputHandler> CreateAvailableInputHandlers() => new InputHandler[] { };
 
         public System.Drawing.Size Resolution { get; set; } = new System.Drawing.Size { Width = 1280, Height = 600 };

--- a/osu-replay-viewer/OsuGameRecorder.cs
+++ b/osu-replay-viewer/OsuGameRecorder.cs
@@ -171,7 +171,7 @@ namespace osu_replay_renderer_netcore
         {
             // Apply some stuffs
             config.SetValue(FrameworkSetting.ConfineMouseMode, ConfineMouseMode.Never);
-            if (!(Host is WindowsRecordGameHost)) config.SetValue(FrameworkSetting.FrameSync, FrameSync.VSync);
+            if (!(Host is ReplayRecordGameHost)) config.SetValue(FrameworkSetting.FrameSync, FrameSync.VSync);
             Audio.Balance.Value = 0;
             Audio.TrackMixer.Balance.Value = 0;
             Audio.SampleMixer.Balance.Value = 0;
@@ -209,7 +209,7 @@ namespace osu_replay_renderer_netcore
                 var getHandle = BassAudioMixer.GetDeclaredMethod("get_Handle");
                 int trackHandle = (int)getHandle.Invoke(Audio.TrackMixer, null);
                 int sampleHandle = (int)getHandle.Invoke(Audio.SampleMixer, null);*/
-                if (headless is WindowsHeadlessGameHost wrv)
+                if (headless is ReplayHeadlessGameHost wrv)
                 {
                     /*wrv.TrackMixerHandle = trackHandle;
                     wrv.SampleMixerHandle = sampleHandle;*/
@@ -248,16 +248,16 @@ namespace osu_replay_renderer_netcore
                         statisticsPanel.ToggleVisibility();
                     }, 2500);
                     
-                    if (Host is WindowsRecordGameHost || Host is HeadlessGameHost)
+                    if (Host is ReplayRecordGameHost || Host is HeadlessGameHost)
                     {
                         Scheduler.AddDelayed(() =>
                         {
-                            if (Host is WindowsRecordGameHost recordHost) recordHost.UsingEncoder = false;
-                            if (Host is WindowsHeadlessGameHost headlessHost && headlessHost.OutputAudioToFile != null) headlessHost.UsingAudioRecorder = false;
+                            if (Host is ReplayRecordGameHost recordHost) recordHost.UsingEncoder = false;
+                            if (Host is ReplayHeadlessGameHost headlessHost && headlessHost.OutputAudioToFile != null) headlessHost.UsingAudioRecorder = false;
                         }, 10000);
                         Scheduler.AddDelayed(() =>
                         {
-                            if (Host is WindowsRecordGameHost recordHost)
+                            if (Host is ReplayRecordGameHost recordHost)
                             {
                                 recordHost.Encoder.FFmpeg.StandardInput.Close();
                                 recordHost.Encoder = null;
@@ -267,7 +267,7 @@ namespace osu_replay_renderer_netcore
                     }
                 };
             }
-            if (newScreen is RecorderReplayPlayer player && Host is WindowsRecordGameHost)
+            if (newScreen is RecorderReplayPlayer player && Host is ReplayRecordGameHost)
             {
                 player.ManipulateClock = true;
 

--- a/osu-replay-viewer/Program.cs
+++ b/osu-replay-viewer/Program.cs
@@ -159,7 +159,7 @@ namespace osu_replay_renderer_netcore
             {
                 if (headlessOutputFile != null) if (!AskFileDelete(yesFlag, headlessOutputFile)) return;
 
-                host = new WindowsHeadlessGameHost("osu", false, true)
+                host = new ReplayHeadlessGameHost("osu", false, true)
                 {
                     OutputAudioToFile = headlessOutputFile,
                     AudioInputDevice = headlessInput,
@@ -170,7 +170,7 @@ namespace osu_replay_renderer_netcore
             {
                 if (!AskFileDelete(yesFlag, recordOutput)) return;
 
-                var host2 = new WindowsRecordGameHost("osu", recordFPS * Math.Max(recordFramesBlending, 1));
+                var host2 = new ReplayRecordGameHost("osu", recordFPS * Math.Max(recordFramesBlending, 1));
                 host2.Resolution = recordResolution;
                 host2.Encoder = new CustomHosts.Record.ExternalFFmpegEncoder()
                 {


### PR DESCRIPTION
This PR will read game data specified in ``XDG_DATA_HOME`` environment variable on Linux or macOS. If that variable does not exists, it will uses ``~/.local/share``.

Closing #9 